### PR TITLE
- Removing unused rule variables rsyslog_rules, rsyslog_group_rules,

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ It is required to run the tests as a user who is authorized to run the 'docker' 
 without using sudo.  This is typically accomplished by adding your user to the 'docker'
 group on your system.
 
-Additionally, there is a challenge around python-libselinux on platforms that use SELinux.
+Additionally, there is a challenge around python-libselinux (python3-libselinux for python3) on platforms that use SELinux.
 If you are using a virtualenv, you need to make sure that the selinux python module is
 available in the virtualenv.  Even if it is installed on your ansible controller host
 and the target host, some of the tasks that are delegated to the locahost will use the

--- a/roles/rsyslog/defaults/main.yaml
+++ b/roles/rsyslog/defaults/main.yaml
@@ -35,7 +35,8 @@ rsyslog_work_dir: '/var/lib/rsyslog'
 
 # rsyslog_capabilities
 #
-# List of different capabilities to configure. See :ref:`rsyslog_capabilities`
+# List of different capabilities to configure.
+# Example:
 # rsyslog_capabilities: [ 'network', 'remote-files', 'tls' ]
 rsyslog_capabilities: []
 
@@ -285,37 +286,6 @@ rsyslog_weight_map:
   'rulesets': '50'
   'input': '90'
   'inputs': '90'
-
-# rsyslog_rules
-#
-# List of YAML dictionaries, each dictionary should contain ``rsyslogd``
-# configuration in a special format. See :ref:`rsyslog_rules` for more
-# details. This list should be used for configuration of all hosts in the
-# inventory.
-rsyslog_rules: []
-
-# rsyslog_group_rules
-#
-# List of YAML dictionaries, each dictionary should contain ``rsyslogd``
-# configuration in a special format. See :ref:`rsyslog_rules` for more
-# details. This list should be used for configuration of a group of hosts in
-# the inventory.
-rsyslog_group_rules: []
-
-# rsyslog_host_rules
-#
-# List of YAML dictionaries, each dictionary should contain ``rsyslogd``
-# configuration in a special format. See :ref:`rsyslog_rules` for more
-# details. This list should be used for configuration of specific hosts in the
-# inventory.
-rsyslog_host_rules: []
-
-# rsyslog_dependent_rules
-#
-# List of YAML dictionaries, each dictionary should contain ``rsyslogd``
-# configuration in a special format. See :ref:`rsyslog_rules` for more
-# details. This list should be used for configuration by other Ansible roles.
-rsyslog_dependent_rules: []
 
 # __rsyslog_.*_rules
 #

--- a/roles/rsyslog/roles/input_roles/basics/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/basics/defaults/main.yaml
@@ -23,9 +23,8 @@ rsyslog_input_log_tag: "container"
 
 # __rsyslog_basics_rules
 #
-# List of YAML dictionaries, each dictionary should contain ``rsyslogd``
-# configuration in a special format. See :ref:`rsyslog_rules` for more
-# details. This list specifies basics ``rsyslogd`` example configuration.
+# List of YAML dictionaries, each dictionary should contain ``rsyslogd`` configuration
+# in a special format. This list specifies basics ``rsyslogd`` example configuration.
 __rsyslog_basics_rules:
   - '{{ __rsyslog_conf_local_basics_modules }}'
   - '{{ __rsyslog_conf_default_rulesets }}'

--- a/roles/rsyslog/roles/input_roles/basics/vars/main.yaml
+++ b/roles/rsyslog/roles/input_roles/basics/vars/main.yaml
@@ -1,3 +1,5 @@
+# Basic rpm packages
+
 # __rsyslog_basics_packages
 #
 # List of default rpm packages to install.

--- a/roles/rsyslog/roles/input_roles/files/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/files/defaults/main.yaml
@@ -18,9 +18,8 @@ rsyslog_input_log_tag: "container"
 
 # __rsyslog_files_input_rules
 #
-# List of YAML dictionaries, each dictionary should contain ``rsyslogd``
-# configuration in a special format. See :ref:`rsyslog_rules` for more
-# details. This list specifies imfile ``rsyslogd`` example configuration.
+# List of YAML dictionaries, each dictionary should contain ``rsyslogd`` configuration
+# in a special format. This list specifies imfile ``rsyslogd`` example configuration.
 __rsyslog_files_input_rules:
   - '{{ __rsyslog_conf_imfile_modules }}'
   - '{{ __rsyslog_conf_imfile_rulesets }}'

--- a/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/defaults/main.yaml
@@ -2,10 +2,6 @@
 # oVirt configuration
 # ---------------------
 
-# oVirt rpm packages
-# adding rsyslog_logging_packages
-# ------------------
-
 # Available configuration set
 # ----------------------------
 

--- a/roles/rsyslog/roles/input_roles/ovirt/tasks/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/tasks/main.yaml
@@ -2,7 +2,7 @@
 # Deploy configuration files
 - name: Install/Update role packages and generate role configuration files to role subdir
   vars:
-    __rsyslog_packages: "{{ __rsyslog_ovirt_prereq_packages | d([]) + __rsyslog_ovirt_packages | d([]) }}"
+    __rsyslog_packages: "{{ __rsyslog_ovirt_prereq_packages + __rsyslog_ovirt_packages }}"
     __rsyslog_rules: "{{ __rsyslog_ovirt_rules }}"
   include_role:
     name: "{{ role_path }}/../../../"

--- a/roles/rsyslog/roles/input_roles/ovirt/vars/main.yaml
+++ b/roles/rsyslog/roles/input_roles/ovirt/vars/main.yaml
@@ -1,5 +1,11 @@
+# oVirt rpm packages
+
+# __rsyslog_ovirt_prereq_packages
+#
+# List of prerequired rpm packages for oVirt
+__rsyslog_ovirt_prereq_ packages: []
+
 # __rsyslog_ovirt_packages
 #
-# List of rpm packages for Common Logging.
+# List of rpm packages for oVirt
 __rsyslog_ovirt_packages: ['rsyslog-mmnormalize', 'rsyslog-mmjsonparse', 'libfastjson', 'liblognorm', 'libestr']
-__rsyslog_ovirt_prereq_packages: []

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/defaults/main.yaml
@@ -7,10 +7,6 @@
 # Viaq log directory
 rsyslog_viaq_log_dir: '{{ rsyslog_system_log_dir }}/containers'
 
-# Viaq rpm packages
-# adding rsyslog_logging_packages
-# ------------------
-
 # Available configuration set
 # ----------------------------
 

--- a/roles/rsyslog/roles/input_roles/viaq-k8s/vars/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq-k8s/vars/main.yaml
@@ -1,4 +1,6 @@
+# Viaq-kubernetes rpm packages
+
 # __rsyslog_viaq_k8s_packages
 #
-# List of rpm packages for Common Logging.
+# List of rpm packages for viaq_kubernetes
 __rsyslog_viaq_k8s_packages: ['rsyslog-mmjsonparse', 'rsyslog-mmkubernetes']

--- a/roles/rsyslog/roles/input_roles/viaq/defaults/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/defaults/main.yaml
@@ -2,10 +2,6 @@
 # Viaq configuration
 # ---------------------
 
-# Viaq rpm packages
-# adding rsyslog_logging_packages
-# ------------------
-
 # Available configuration set
 # ----------------------------
 

--- a/roles/rsyslog/roles/input_roles/viaq/vars/main.yaml
+++ b/roles/rsyslog/roles/input_roles/viaq/vars/main.yaml
@@ -1,5 +1,11 @@
+# Viaq rpm packages
+
+# __rsyslog_viaq_prereq_packages
+#
+# List of prerequired rpm packages for viaq
+__rsyslog_viaq_prereq_packages: ['nmap-ncat', 'systemd-python', 'policycoreutils', 'checkpolicy', 'policycoreutils-python']
+
 # __rsyslog_viaq_packages
 #
-# List of rpm packages for Common Logging.
-__rsyslog_viaq_prereq_packages: ['nmap-ncat', 'systemd-python', 'policycoreutils', 'checkpolicy', 'policycoreutils-python']
+# List of rpm packages for viaq
 __rsyslog_viaq_packages: ['rsyslog-mmnormalize']

--- a/roles/rsyslog/roles/output_roles/elasticsearch/vars/main.yaml
+++ b/roles/rsyslog/roles/output_roles/elasticsearch/vars/main.yaml
@@ -1,3 +1,5 @@
+# Elasticsearch rpm packages
+
 # __rsyslog_elasticsearch_package
 #
 # List of rpm packages for Elasticsearch output.

--- a/roles/rsyslog/roles/output_roles/files/vars/main.yaml
+++ b/roles/rsyslog/roles/output_roles/files/vars/main.yaml
@@ -1,4 +1,6 @@
-# __rsyslog_files_output_package
+# Local file output rpm packages
+
+# __rsyslog_files_output_packages
 #
 # List of rpm packages for Files output.
 __rsyslog_files_output_packages: []

--- a/roles/rsyslog/roles/output_roles/forwards/vars/main.yaml
+++ b/roles/rsyslog/roles/output_roles/forwards/vars/main.yaml
@@ -1,4 +1,6 @@
-# __rsyslog_forwards_output_package
+# Forwarding rpm packages
+
+# __rsyslog_forwards_output_packages
 #
-# List of rpm packages for Forwards output.
+# List of rpm packages for Forwarding output.
 __rsyslog_forwards_output_packages: []


### PR DESCRIPTION
  rsyslog_host_rules and rsyslog_dependent_rules from
  roles/rsyslog/defaults/main.yaml.
- Fixing obsolete comments.